### PR TITLE
Prefer `thiserror` instead of `eyre` for library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [0.1.4] - 2021-12-20
+### Added
+### Changed
+- Error handling: use `thiserror` instead of `eyre`, allowing users to match on enum errors
+### Fixed
+### Removed
+
+---
 ## [0.1.3] - 2021-12-06
 ### Added
 - Add access policy comparison (trait `PartialEq`) with ABE attributes commutativity
@@ -10,8 +18,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Bug in hierarchical axis, order DOES matter now
 ### Removed
----
 
+---
 ## [0.1.2] - 2021-12-03
 ### Added
 - Add CHANGELOG and LICENSE files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,12 @@ license = "MIT/Apache-2.0"
 name = "abe_gpsw"
 repository = "https://github.com/Cosmian/abe_gpsw"
 version = "0.1.3"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 name = "abe_gpsw"
 
 [dependencies]
 cosmian_bls12_381 = "0.4"
-eyre = "0.6"
 ff = "0.9"
 getrandom = {version = "0.2", features = ["js"]}
 group = "0.9"
@@ -30,4 +28,5 @@ regex = "1.5.4"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 sha3 = "0.9"
+thiserror = "1"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 name = "abe_gpsw"
 repository = "https://github.com/Cosmian/abe_gpsw"
-version = "0.1.3"
+version = "0.1.4"
 
 [lib]
 name = "abe_gpsw"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Fine-Grained Access Control of Encrypted Data](https://eprint.iacr.org/2006/309.
 [Latest Version]: https://img.shields.io/crates/v/abe_gpsw.svg
 [crates.io]: https://crates.io/crates/abe_gpsw
 
-
 # Introduction
 
 In a standard public-key encryption scheme, each user has his own public key and secret key, so that if one wants to encrypt a message intended for several receivers (for example, according to their jobs in a company), it will be necessary to compute the ciphertext for each public key of each recipient, which implies a huge loss of time and space.
@@ -30,6 +29,7 @@ Some specificities of ABE schemes are:
 - secondly, private keys are constructed from a list of attributes (or a policy) instead of an identity. Anyone who has all the attributes (or a valid access policy) can read the message.
 
 ![img](figs/CP-vs-KP.png)
+
 ## Ciphertext-Policy
 
 In Ciphertext-Policy Attribute-Based Encryption (CP-ABE), the access policy is encoded in the encrypted message; a ciphertext specifies an access policy over a defined universe of attributes within the system. A user’s private key is associated with a set of attributes which corresponds to a user’s identity: a user will be able to decrypt a ciphertext, if and only if his attributes satisfy the policy of the respective ciphertext. See for example [BSW07](https://hal.archives-ouvertes.fr/hal-01788815/document).
@@ -70,15 +70,15 @@ Contrarily to the `Department` axis, the `Security Level` axis is hierarchical: 
 
 All unique attribute names (7 in the example above) are derived by concatenating the axis names and the possible values for that axis, and are assigned a unique attribute value:
 
-| Attribute name         |  Value  |
-|------------------------|---------|
-| Department::HR         |    1    |
-| Department::FIN        |    2    |
-| Department::MKG        |    3    |
-| Department::R&D        |    4    |
-| Security Level::high   |    5    |
-| Security Level::medium |    6    |
-| Security Level::low    |    7    |
+| Attribute name         | Value |
+| ---------------------- | ----- |
+| Department::HR         | 1     |
+| Department::FIN        | 2     |
+| Department::MKG        | 3     |
+| Department::R&D        | 4     |
+| Security Level::high   | 5     |
+| Security Level::medium | 6     |
+| Security Level::low    | 7     |
 
 From the master secret key, a derived decryption key for a user of the marketing department (`MKG`) with a `medium` security level will hold an access policy expressed as the boolean expression:
 

--- a/src/bilinear_map/mod.rs
+++ b/src/bilinear_map/mod.rs
@@ -2,7 +2,7 @@ use core::ops::{Add, Div, Mul, Neg, Sub};
 
 use rand::{CryptoRng, RngCore, SeedableRng};
 
-use crate::gpsw::AsBytes;
+use crate::{error::FormatErr, gpsw::AsBytes};
 
 pub mod bls12_381;
 
@@ -51,11 +51,12 @@ pub trait BilinearMap: Default {
     fn gen_rand_scalar_inner<R: CryptoRng + RngCore>(
         &self,
         rng: &mut R,
-    ) -> eyre::Result<Self::Scalar>;
+    ) -> Result<Self::Scalar, FormatErr>;
 
-    fn gen_rand_gt_inner<R: CryptoRng + RngCore>(&self, rng: &mut R) -> eyre::Result<Self::Gt>;
+    fn gen_rand_gt_inner<R: CryptoRng + RngCore>(&self, rng: &mut R)
+    -> Result<Self::Gt, FormatErr>;
 
-    fn msg_to_scalar(&self, msg: &[u8]) -> eyre::Result<Self::Scalar>;
+    fn msg_to_scalar(&self, msg: &[u8]) -> Result<Self::Scalar, FormatErr>;
 
     // Group
     // compute g1^x
@@ -91,12 +92,12 @@ pub trait BilinearMap: Default {
     //
     // Derived functions
     //
-    fn gen_random_scalar(&self) -> eyre::Result<Self::Scalar> {
+    fn gen_random_scalar(&self) -> Result<Self::Scalar, FormatErr> {
         let mut rng = rand_hc::Hc128Rng::from_entropy();
         self.gen_rand_scalar_inner(&mut rng)
     }
 
-    fn gen_random_scalar_vector(&self, size: usize) -> eyre::Result<Vec<Self::Scalar>> {
+    fn gen_random_scalar_vector(&self, size: usize) -> Result<Vec<Self::Scalar>, FormatErr> {
         let mut rng = rand_hc::Hc128Rng::from_entropy();
         std::iter::repeat_with(|| self.gen_rand_scalar_inner(&mut rng))
             .take(size)
@@ -111,12 +112,12 @@ pub trait BilinearMap: Default {
         vec_x.iter().map(|x| self.g2_gen_exp(x)).collect()
     }
 
-    fn msg_to_gt(&self, msg: &[u8]) -> eyre::Result<Self::Gt> {
+    fn msg_to_gt(&self, msg: &[u8]) -> Result<Self::Gt, FormatErr> {
         let scl = self.msg_to_scalar(msg)?;
         Ok(self.gt_gen_exp(&scl))
     }
 
-    fn gen_random_msg_in_gt(&self) -> eyre::Result<Self::Gt> {
+    fn gen_random_msg_in_gt(&self) -> Result<Self::Gt, FormatErr> {
         let mut rng = rand_hc::Hc128Rng::from_entropy();
         self.gen_rand_gt_inner(&mut rng)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,99 @@
+use std::{
+    array::TryFromSliceError,
+    convert::From,
+    num::{ParseIntError, TryFromIntError},
+};
+
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum FormatErr {
+    #[error("attribute not found")]
+    AttributeNotFound,
+    #[error("{} is missing{}", 
+        .item.clone().unwrap_or_else(|| "attribute".to_string()),
+        match .axis_name {
+            Some(axis) => format!(" in axis {}", axis),
+            None => "".to_string(),
+    })]
+    MissingAttribute {
+        item: Option<String>,
+        axis_name: Option<String>,
+    },
+    #[error("{0} is missing")]
+    MissingAxis(String),
+    #[error("attribute {0} expected in {1:?}")]
+    ExpectedAttribute(String, Vec<String>),
+    #[error("unsupported operand {0}")]
+    UnsupportedOperand(String),
+    #[error("unsupported operator {0}")]
+    UnsupportedOperator(String),
+    #[error("attribute capacity overflow")]
+    CapacityOverflow,
+    #[error("attribute {0} for {1} already exists")]
+    ExistingAttribute(String, String),
+    #[error("policy {0} already exists")]
+    ExistingPolicy(String),
+    #[error("invalid size")]
+    InvalidSize(String),
+    #[error("{0}")]
+    Deserialization(String),
+    #[error("{0}")]
+    InternalOperation(String),
+    #[error("invalid formula: {0}")]
+    InvalidFormula(String),
+    #[error("conversion failed")]
+    ConversionFailed,
+    #[error("error parsing formula")]
+    ParsingError(ParsingError),
+}
+
+impl From<TryFromIntError> for FormatErr {
+    fn from(_e: TryFromIntError) -> Self {
+        FormatErr::ConversionFailed
+    }
+}
+
+impl From<TryFromSliceError> for FormatErr {
+    fn from(_e: TryFromSliceError) -> Self {
+        FormatErr::ConversionFailed
+    }
+}
+
+impl From<ParseIntError> for FormatErr {
+    fn from(_e: ParseIntError) -> Self {
+        FormatErr::ConversionFailed
+    }
+}
+
+impl From<regex::Error> for FormatErr {
+    fn from(e: regex::Error) -> Self {
+        ParsingError::RegexError(e).into()
+    }
+}
+
+impl From<serde_json::Error> for FormatErr {
+    fn from(e: serde_json::Error) -> Self {
+        FormatErr::Deserialization(e.to_string())
+    }
+}
+
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum ParsingError {
+    #[error("{0}")]
+    UnexpectedCharacter(String),
+    #[error("{0}")]
+    UnexpectedEnd(String),
+    #[error("empty string")]
+    EmptyString,
+    #[error("wrong range")]
+    RangeError,
+    #[error("{0}")]
+    RegexError(#[from] regex::Error),
+}
+
+impl From<ParsingError> for FormatErr {
+    fn from(pe: ParsingError) -> Self {
+        FormatErr::ParsingError(pe)
+    }
+}

--- a/src/mod_tests.rs
+++ b/src/mod_tests.rs
@@ -1,5 +1,5 @@
 use super::{bilinear_map::bls12_381::Bls12_381, gpsw::abe::Gpsw, AccessPolicy, Engine, Policy};
-use crate::policy::ap;
+use crate::{error::FormatErr, policy::ap};
 
 /// # Encryption using an Authorization Policy
 /// This test demonstrates how data can be encrypted with policy attributes.
@@ -7,7 +7,7 @@ use crate::policy::ap;
 /// proper attributes. This test also demonstrates revocation of an
 /// attribute value and how to implement forward secrecy.
 #[test]
-fn abe() -> eyre::Result<()> {
+fn abe() -> Result<(), FormatErr> {
     // ## Policy
     // In this demo, we will create a Policy which combines two axes, a
     // 'security level' and a 'department'. An user will be able to decrypt

--- a/src/msp_tests.rs
+++ b/src/msp_tests.rs
@@ -1,4 +1,5 @@
 use crate::{
+    error::FormatErr,
     gpsw::AsBytes,
     msp::{
         MonotoneSpanProgram, Node,
@@ -6,12 +7,12 @@ use crate::{
     },
 };
 
-fn to_msp(val: &str) -> eyre::Result<MonotoneSpanProgram<i32>> {
+fn to_msp(val: &str) -> Result<MonotoneSpanProgram<i32>, FormatErr> {
     Node::parse(val)?.to_msp()
 }
 
 #[test]
-fn parsing() -> eyre::Result<()> {
+fn parsing() -> Result<(), FormatErr> {
     let a = Box::new(Leaf(1));
     let b = Box::new(Leaf(2));
     let c = Box::new(Leaf(3));
@@ -41,7 +42,7 @@ fn parsing() -> eyre::Result<()> {
 }
 
 #[test]
-fn test_equality() -> eyre::Result<()> {
+fn test_equality() -> Result<(), FormatErr> {
     // can be written let formula = a & (d | (b & c));
     let formula_str = "1 & (4 | (2 & 3))";
     let other_formula = "1 & (4 | (2 & 3))";
@@ -59,7 +60,7 @@ fn test_equality() -> eyre::Result<()> {
 }
 
 #[test]
-fn parsing_multi() -> eyre::Result<()> {
+fn parsing_multi() -> Result<(), FormatErr> {
     Node::parse("1 & (4 | (2 & 3))")?;
     Node::parse("(1 & 2) | (2 & 3)")?;
     Node::parse("1 | 2")?;
@@ -95,7 +96,7 @@ fn parsing_with_bad_formula() {
 }
 
 #[test]
-fn msp_to_matrix() -> eyre::Result<()> {
+fn msp_to_matrix() -> Result<(), FormatErr> {
     let a = Box::new(Leaf(1));
     let b = Box::new(Leaf(2));
     let c = Box::new(Leaf(3));
@@ -109,7 +110,7 @@ fn msp_to_matrix() -> eyre::Result<()> {
 }
 
 #[test]
-fn msp_as_bytes() -> eyre::Result<()> {
+fn msp_as_bytes() -> Result<(), FormatErr> {
     let a = Box::new(Leaf(1));
     let b = Box::new(Leaf(2));
     let c = Box::new(Leaf(3));

--- a/src/policy_tests.rs
+++ b/src/policy_tests.rs
@@ -1,8 +1,11 @@
 use super::{AccessPolicy, Policy};
-use crate::policy::{ap, attr};
+use crate::{
+    error::FormatErr,
+    policy::{ap, attr},
+};
 
 #[test]
-fn policy_group() -> eyre::Result<()> {
+fn policy_group() -> Result<(), FormatErr> {
     let policy_group = Policy::new(1000)
         .add_axis(
             "Security Level",


### PR DESCRIPTION
This PR aims to allow users to match practically on an `enum`