### PR TITLE
upgrade to crypto_base 0.5.1+ allow empty resource UIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 
 ---
+## [0.4.0] - 2022-02-21
+### Added
+### Changed
+- Updated crypto_base to 0.5.1 which introduces a breaking change to hybrid MetaData
+
+### Fixed
+- hybrid crypto: allow empty resource UIDs
+### Removed
+
+---
+
+---
 ## [0.3.0] - 2022-02-04
 ### Added
 FFI to be able to interface with other languages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abe_gpsw"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cosmian_bls12_381",
  "cosmian_crypto_base",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_crypto_base"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1285365efa9ae910ad216ce987d26a3970ea1a1186c4d8439411a99ee1d09511"
+checksum = "3dea27a1074651efe6e05f73ecbe456a69076a31cd722abeb08434e307b188d1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 name = "abe_gpsw"
 repository = "https://github.com/Cosmian/abe_gpsw"
-version = "0.3.0"
+version = "0.4.0"
 
 [lib]
 name = "abe_gpsw"
@@ -27,7 +27,7 @@ ffi = ["interfaces"]
 [dependencies]
 anyhow = { package = "eyre", version = "0.6.0" }
 cosmian_bls12_381 = "0.4"
-cosmian_crypto_base = { version = "0.4", optional = true }
+cosmian_crypto_base = { version = "0.5.1", optional = true }
 ff = "0.9"
 getrandom = { version = "0.2", features = ["js"] }
 group = "0.9"

--- a/src/interfaces/asymmetric_crypto.rs
+++ b/src/interfaces/asymmetric_crypto.rs
@@ -220,7 +220,7 @@ where
             encryption_parameters,
             Metadata {
                 uid: vec![],
-                additional_data: vec![],
+                additional_data: None,
             },
         )?;
         let header_bytes = header.as_bytes()?;

--- a/src/interfaces/hybrid_crypto/tests/mod.rs
+++ b/src/interfaces/hybrid_crypto/tests/mod.rs
@@ -42,7 +42,7 @@ pub fn test_aes_hybrid_encryption() -> anyhow::Result<()> {
     ];
     let meta_data = Metadata {
         uid: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
-        additional_data: vec![10, 11, 12, 13, 14],
+        additional_data: Some(vec![10, 11, 12, 13, 14]),
     };
     let encrypted_header = encrypt_hybrid_header::<Gpsw<Bls12_381>, Aes256GcmCrypto>(
         &policy,


### PR DESCRIPTION
## [0.4.0] - 2022-02-21
### Added
### Changed
- Updated crypto_base to 0.5.1 which introduces a breaking change to hybrid MetaData

### Fixed
- hybrid crypto: allow empty resource UIDs
### Removed

---