### PR TITLE
Feature/keep binaries in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,16 @@ jobs:
           args: --all-features -- -D warnings
 
   test:
-    name: Test and build with all features on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Test on ${{ matrix.target }} for feature ${{ matrix.feature }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            feature: ffi
+          - target: wasm32-unknown-unknown
+            feature: wasm_bindgen
 
     steps:
       - uses: actions/checkout@v1
@@ -40,37 +45,13 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - run: cargo install wasm-bindgen-cli
+      - run: rustup target add ${{ matrix.target }}
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args:  --all-features --verbose --release
-      - name: Build with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --all-features
-
-  no-std:
-    name: Check no-std target ${{ matrix.target }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - wasm32-unknown-unknown
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - run: rustup target add ${{ matrix.target }}
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --target ${{ matrix.target }} --features wasm_bindgen
+          args: --verbose --release --features ${{ matrix.feature }} --target ${{ matrix.target }}
 
   doc-links:
     name: Stable lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: release ${{ matrix.target }} for feature ${{ matrix.feature }}
+    env:
+      PROJECT_NAME_UNDERSCORE: abe_gpsw
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            feature: ffi
+          - target: x86_64-unknown-linux-musl
+            feature: ffi
+          - target: x86_64-unknown-linux-gnu
+            feature: ffi
+          - target: wasm32-unknown-unknown
+            feature: wasm_bindgen
+          - target: wasm32-wasi
+            feature: wasm_bindgen
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: sudo apt-get install gcc-mingw-w64
+      - run: rustup target add ${{ matrix.target }}
+      - name: Build release with all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose --features ${{ matrix.feature }} --target ${{ matrix.target }}
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PROJECT_NAME_UNDERSCORE }}_${{ matrix.target }}_${{ matrix.feature }}
+          path: target/${{ matrix.target }}/release/*${{ env.PROJECT_NAME_UNDERSCORE }}*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "*"
 
 jobs:
   release:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
         "rustup",
         "strncpy",
         "thiserror",
+        "wasi",
         "webassembly"
     ],
 }


### PR DESCRIPTION
- test wasm binaries in CI (thanks to wasm-bindgen-cli)
- for releases, build ABE binaries according to Rust-targets (linux, windows, wasm32) and features (ffi or wasm-bindgen)
