### PR TITLE
Ffi speed thread safe + use integer handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## [0.6.1] - 2022-03-15
+### Added
+### Changed
+- FFI made caches use int handle ids rather than pointers
+### Fixed
+- FFI made caches thread safe
+### Removed
+
+---
+
+
+---
 ## [0.6.0] - 2022-03-11
 ### Added
 - FFI hybrid encryption using a cache to speed up encryption/decryption (x4 on encryption, x2 on decryption)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "group",
  "hex",
  "js-sys",
+ "lazy_static",
  "rand",
  "rand_core 0.5.1",
  "rand_hc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abe_gpsw"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cosmian_bls12_381",
  "cosmian_crypto_base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ js-sys = { version = "0.3", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 group = "0.9"
 hex = "0.4"
+lazy_static = "1.4.0"
 rand = "0.8"
 rand_core = { version = "0.5", features = ["getrandom"] }
 rand_hc = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 name = "abe_gpsw"
 repository = "https://github.com/Cosmian/abe_gpsw"
-version = "0.6.0"
+version = "0.6.1"
 
 [lib]
 name = "abe_gpsw"

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -15,7 +15,7 @@ use {
         },
     },
     std::{
-        ffi::{c_void, CStr, CString},
+        ffi::{CStr, CString},
         os::raw::{c_char, c_int},
     },
 };
@@ -308,9 +308,6 @@ pub unsafe fn bench_ffi_header_encryption_using_cache() -> anyhow::Result<()> {
         additional_data: Some(vec![10, 11, 12, 13, 14]),
     };
 
-    let mut cache_ptr: *mut c_void = std::ptr::null_mut();
-    let cache_ptr_ptr: *mut *mut c_void = &mut cache_ptr;
-
     let policy_cs = CString::new(serde_json::to_string(&policy)?.as_str())?;
     let policy_ptr = policy_cs.as_ptr();
 
@@ -318,12 +315,7 @@ pub unsafe fn bench_ffi_header_encryption_using_cache() -> anyhow::Result<()> {
     let public_key_ptr = public_key_bytes.as_ptr() as *const c_char;
     let public_key_len = public_key_bytes.len() as i32;
 
-    unwrap_ffi_error(h_aes_create_encryption_cache(
-        cache_ptr_ptr,
-        policy_ptr,
-        public_key_ptr,
-        public_key_len,
-    ))?;
+    let cache_ptr = h_aes_create_encryption_cache(policy_ptr, public_key_ptr, public_key_len);
 
     let mut symmetric_key = vec![0u8; 32];
     let symmetric_key_ptr = symmetric_key.as_mut_ptr() as *mut c_char;
@@ -344,7 +336,7 @@ pub unsafe fn bench_ffi_header_encryption_using_cache() -> anyhow::Result<()> {
             &mut symmetric_key_len,
             header_bytes_ptr,
             &mut header_bytes_len,
-            cache_ptr_ptr,
+            cache_ptr,
             attributes_ptr,
             meta_data.uid.as_ptr() as *const c_char,
             meta_data.uid.len() as i32,
@@ -355,7 +347,7 @@ pub unsafe fn bench_ffi_header_encryption_using_cache() -> anyhow::Result<()> {
     let avg_time = before.elapsed().as_micros() / loops;
     println!("avg time: {} micro seconds", avg_time);
 
-    unwrap_ffi_error(h_aes_destroy_encryption_cache(cache_ptr_ptr))?;
+    unwrap_ffi_error(h_aes_destroy_encryption_cache(cache_ptr))?;
     Ok(())
 }
 
@@ -469,14 +461,7 @@ pub unsafe fn bench_ffi_header_decryption_using_cache() -> anyhow::Result<()> {
     let user_decryption_key_ptr = user_decryption_key_bytes.as_ptr() as *const c_char;
     let user_decryption_key_len = user_decryption_key_bytes.len() as i32;
 
-    let mut cache_ptr: *mut c_void = std::ptr::null_mut();
-    let cache_ptr_ptr: *mut *mut c_void = &mut cache_ptr;
-
-    unwrap_ffi_error(h_aes_create_decryption_cache(
-        cache_ptr_ptr,
-        user_decryption_key_ptr,
-        user_decryption_key_len,
-    ))?;
+    let cache_ptr = h_aes_create_decryption_cache(user_decryption_key_ptr, user_decryption_key_len);
 
     let loops = 5000;
     let before = Instant::now();
@@ -490,13 +475,13 @@ pub unsafe fn bench_ffi_header_decryption_using_cache() -> anyhow::Result<()> {
             &mut additional_data_len,
             encrypted_header.encrypted_header_bytes.as_ptr() as *const c_char,
             encrypted_header.encrypted_header_bytes.len() as c_int,
-            cache_ptr_ptr,
+            cache_ptr,
         ))?;
     }
     let avg_time = before.elapsed().as_micros() / loops;
     println!("avg time: {} micro seconds", avg_time);
 
-    unwrap_ffi_error(h_aes_destroy_decryption_cache(cache_ptr_ptr))?;
+    unwrap_ffi_error(h_aes_destroy_decryption_cache(cache_ptr))?;
 
     Ok(())
 }

--- a/src/interfaces/ffi/tests.rs
+++ b/src/interfaces/ffi/tests.rs
@@ -164,6 +164,19 @@ unsafe fn decrypt_header(
     })
 }
 
+unsafe fn unwrap_ffi_create_object(pointer: *mut c_void) -> anyhow::Result<*mut c_void> {
+    if pointer.is_null() {
+        let mut message_bytes_key = vec![0u8; 4096];
+        let message_bytes_ptr = message_bytes_key.as_mut_ptr() as *mut c_char;
+        let mut message_bytes_len = message_bytes_key.len() as c_int;
+        get_last_error(message_bytes_ptr, &mut message_bytes_len);
+        let cstr = CStr::from_ptr(message_bytes_ptr);
+        anyhow::bail!("ERROR creating object: {}", cstr.to_str()?);
+    } else {
+        Ok(pointer)
+    }
+}
+
 unsafe fn unwrap_ffi_error(val: i32) -> anyhow::Result<()> {
     if val != 0 {
         let mut message_bytes_key = vec![0u8; 4096];
@@ -195,9 +208,6 @@ unsafe fn encrypt_header_using_cache(
         .unwrap();
     let policy: Policy = serde_json::from_slice(&hex::decode(policy_hex)?)?;
 
-    let mut cache_ptr: *mut c_void = std::ptr::null_mut();
-    let cache_ptr_ptr: *mut *mut c_void = &mut cache_ptr;
-
     let policy_cs = CString::new(serde_json::to_string(&policy)?.as_str())?;
     let policy_ptr = policy_cs.as_ptr();
 
@@ -205,8 +215,7 @@ unsafe fn encrypt_header_using_cache(
     let public_key_ptr = public_key_bytes.as_ptr() as *const c_char;
     let public_key_len = public_key_bytes.len() as i32;
 
-    unwrap_ffi_error(h_aes_create_encryption_cache(
-        cache_ptr_ptr,
+    let cache_ptr = unwrap_ffi_create_object(h_aes_create_encryption_cache(
         policy_ptr,
         public_key_ptr,
         public_key_len,
@@ -233,7 +242,7 @@ unsafe fn encrypt_header_using_cache(
         &mut symmetric_key_len,
         encrypted_header_ptr,
         &mut encrypted_header_len,
-        cache_ptr_ptr,
+        cache_ptr,
         attributes_ptr,
         meta_data.uid.as_ptr() as *const c_char,
         meta_data.uid.len() as i32,
@@ -252,7 +261,7 @@ unsafe fn encrypt_header_using_cache(
     )
     .to_vec();
 
-    unwrap_ffi_error(h_aes_destroy_encryption_cache(cache_ptr_ptr))?;
+    unwrap_ffi_error(h_aes_destroy_encryption_cache(cache_ptr))?;
 
     Ok(EncryptedHeader {
         symmetric_key: symmetric_key_,
@@ -274,11 +283,7 @@ unsafe fn decrypt_header_using_cache(
     let user_decryption_key_ptr = user_decryption_key_bytes.as_ptr() as *const c_char;
     let user_decryption_key_len = user_decryption_key_bytes.len() as i32;
 
-    let mut cache_ptr: *mut c_void = std::ptr::null_mut();
-    let cache_ptr_ptr: *mut *mut c_void = &mut cache_ptr;
-
-    unwrap_ffi_error(h_aes_create_decryption_cache(
-        cache_ptr_ptr,
+    let cache_ptr = unwrap_ffi_create_object(h_aes_create_decryption_cache(
         user_decryption_key_ptr,
         user_decryption_key_len,
     ))?;
@@ -304,7 +309,7 @@ unsafe fn decrypt_header_using_cache(
         &mut additional_data_len,
         header.encrypted_header_bytes.as_ptr() as *const c_char,
         header.encrypted_header_bytes.len() as c_int,
-        cache_ptr_ptr,
+        cache_ptr,
     ))?;
 
     let symmetric_key_ = <Aes256GcmCrypto as SymmetricCrypto>::Key::parse(
@@ -320,7 +325,7 @@ unsafe fn decrypt_header_using_cache(
     )
     .to_vec();
 
-    unwrap_ffi_error(h_aes_destroy_decryption_cache(cache_ptr_ptr))?;
+    unwrap_ffi_error(h_aes_destroy_decryption_cache(cache_ptr))?;
 
     Ok(DecryptedHeader {
         symmetric_key: symmetric_key_,
@@ -338,6 +343,7 @@ fn test_ffi_hybrid_header() -> anyhow::Result<()> {
             uid: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
             additional_data: Some(vec![10, 11, 12, 13, 14]),
         };
+
         let encrypted_header = encrypt_header(&meta_data)?;
         let decrypted_header = decrypt_header(&encrypted_header)?;
 


### PR DESCRIPTION
## [0.6.1] - 2022-03-15
### Added
### Changed
- FFI made caches use int handle ids rather than pointers
### Fixed
- FFI made caches thread safe
### Removed
